### PR TITLE
Improve folder management and note workflows

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('отображает пустое состояние и список папок', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+
+  expect(screen.getByText('Папки')).toBeInTheDocument();
+  expect(screen.getByText('Все заметки')).toBeInTheDocument();
+  expect(screen.getByText('Заметок пока нет.')).toBeInTheDocument();
 });

--- a/src/components/EditNoteModal.js
+++ b/src/components/EditNoteModal.js
@@ -1,19 +1,29 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import TagsInput from 'react-tagsinput';
 import 'react-tagsinput/react-tagsinput.css';
 
-const EditNoteModal = ({ editedNote, onSave, onClose }) => {
+const EditNoteModal = ({ editedNote, onSave, onClose, folders = [] }) => {
   const [editedTitle, setEditedTitle] = useState(editedNote.title);
-  const [editedDescription, setEditedDescription] = useState(editedNote.description);
+  const [editedDescription, setEditedDescription] = useState(
+    editedNote.description
+  );
   const [tags, setTags] = useState(editedNote.tags || []);
+  const [folderId, setFolderId] = useState(editedNote.folderId || '');
+
+  useEffect(() => {
+    setEditedTitle(editedNote.title);
+    setEditedDescription(editedNote.description);
+    setTags(editedNote.tags || []);
+    setFolderId(editedNote.folderId || '');
+  }, [editedNote]);
 
   const handleSave = () => {
     onSave({
       ...editedNote,
       title: editedTitle,
       description: editedDescription,
-      tags: tags,
-      updated: true,
+      tags,
+      folderId: folderId || null,
     });
     onClose();
   };
@@ -46,6 +56,24 @@ const EditNoteModal = ({ editedNote, onSave, onClose }) => {
                 value={editedDescription}
                 onChange={(e) => setEditedDescription(e.target.value)}
               />
+            </div>
+          </div>
+          <div className="field">
+            <label className="label">Папка</label>
+            <div className="control">
+              <div className="select is-fullwidth">
+                <select
+                  value={folderId}
+                  onChange={(event) => setFolderId(event.target.value)}
+                >
+                  <option value="">Без папки</option>
+                  {folders.map((folder) => (
+                    <option key={folder.id} value={folder.id}>
+                      {folder.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </div>
           </div>
           <div className="field">

--- a/src/components/FolderForm.js
+++ b/src/components/FolderForm.js
@@ -1,20 +1,37 @@
-// FolderForm.js
 import React, { useState } from 'react';
 
 const FolderForm = ({ addFolder }) => {
   const [folderName, setFolderName] = useState('');
 
-  const handleSubmit = () => {
-    if (folderName.trim() !== '') {
-      addFolder(folderName);
-      setFolderName('');
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const trimmedName = folderName.trim();
+    if (!trimmedName) {
+      return;
     }
+    addFolder(trimmedName);
+    setFolderName('');
   };
 
   return (
-    <div>
-      {/* Форма для создания папки */}
-    </div>
+    <form onSubmit={handleSubmit} className="mb-4">
+      <div className="field has-addons">
+        <div className="control is-expanded">
+          <input
+            className="input"
+            type="text"
+            placeholder="Название новой папки"
+            value={folderName}
+            onChange={(event) => setFolderName(event.target.value)}
+          />
+        </div>
+        <div className="control">
+          <button type="submit" className="button is-link">
+            Добавить
+          </button>
+        </div>
+      </div>
+    </form>
   );
 };
 

--- a/src/components/FolderList.js
+++ b/src/components/FolderList.js
@@ -1,8 +1,142 @@
-// FolderList.js
-import React from 'react';
+import React, { useState } from 'react';
+import FolderForm from './FolderForm';
 
-const FolderList = ({ folders }) => {
-  // Отобразите список папок здесь
+const FolderList = ({
+  folders = [],
+  onAddFolder,
+  onDeleteFolder,
+  onEditFolder,
+  selectedFolderId,
+  onSelectFolder,
+}) => {
+  const [folderBeingEdited, setFolderBeingEdited] = useState(null);
+  const [editedName, setEditedName] = useState('');
+
+  const startEditing = (folder) => {
+    setFolderBeingEdited(folder.id);
+    setEditedName(folder.name);
+  };
+
+  const cancelEditing = () => {
+    setFolderBeingEdited(null);
+    setEditedName('');
+  };
+
+  const saveEditing = () => {
+    if (!editedName.trim()) {
+      return;
+    }
+    onEditFolder(folderBeingEdited, editedName);
+    cancelEditing();
+  };
+
+  return (
+    <div className="box">
+      <h2 className="title is-5">Папки</h2>
+      <FolderForm addFolder={onAddFolder} />
+      <div className="menu">
+        <ul className="menu-list">
+          <li>
+            <button
+              type="button"
+              className={`button is-ghost is-fullwidth has-text-left ${
+                selectedFolderId === null ? 'is-link' : ''
+              }`}
+              onClick={() => onSelectFolder(null)}
+            >
+              <span className="icon-text">
+                <span className="icon">
+                  <i className="fas fa-inbox"></i>
+                </span>
+                <span>Все заметки</span>
+              </span>
+            </button>
+          </li>
+          {folders.map((folder) => (
+            <li key={folder.id} className="mt-2">
+              {folderBeingEdited === folder.id ? (
+                <div className="field has-addons">
+                  <div className="control is-expanded">
+                    <input
+                      className="input"
+                      type="text"
+                      value={editedName}
+                      onChange={(event) => setEditedName(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                          event.preventDefault();
+                          saveEditing();
+                        }
+                        if (event.key === 'Escape') {
+                          event.preventDefault();
+                          cancelEditing();
+                        }
+                      }}
+                    />
+                  </div>
+                  <div className="control">
+                    <button
+                      type="button"
+                      className="button is-success"
+                      onClick={saveEditing}
+                    >
+                      <i className="fas fa-check"></i>
+                    </button>
+                  </div>
+                  <div className="control">
+                    <button
+                      type="button"
+                      className="button"
+                      onClick={cancelEditing}
+                    >
+                      <i className="fas fa-times"></i>
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="folder-item">
+                  <button
+                    type="button"
+                    className={`button is-ghost is-fullwidth has-text-left ${
+                      selectedFolderId === folder.id ? 'is-link' : ''
+                    }`}
+                    onClick={() => onSelectFolder(folder.id)}
+                  >
+                    <span className="icon-text">
+                      <span className="icon">
+                        <i className="fas fa-folder"></i>
+                      </span>
+                      <span>{folder.name}</span>
+                    </span>
+                  </button>
+                  <div className="buttons is-right mt-2">
+                    <button
+                      type="button"
+                      className="button is-warning is-small"
+                      onClick={() => startEditing(folder)}
+                    >
+                      <span className="icon is-small">
+                        <i className="fas fa-edit"></i>
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      className="button is-danger is-small"
+                      onClick={() => onDeleteFolder(folder.id)}
+                    >
+                      <span className="icon is-small">
+                        <i className="fas fa-trash"></i>
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
 };
 
 export default FolderList;

--- a/src/components/NoteForm.js
+++ b/src/components/NoteForm.js
@@ -1,34 +1,45 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import SimpleMDE from 'react-simplemde-editor';
 import 'easymde/dist/easymde.min.css';
 import TagsInput from 'react-tagsinput';
 import 'react-tagsinput/react-tagsinput.css';
 
-const NoteForm = ({ addNote }) => {
+const NoteForm = ({ addNote, folders = [], defaultFolderId }) => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [tags, setTags] = useState([]);
   const [editor, setEditor] = useState(null);
+  const [folderId, setFolderId] = useState(defaultFolderId || '');
 
-  const handleSubmit = () => {
+  useEffect(() => {
+    setFolderId(defaultFolderId || '');
+  }, [defaultFolderId]);
+
+  const resetForm = () => {
+    setTitle('');
+    setDescription('');
+    setTags([]);
+    setFolderId(defaultFolderId || '');
+    if (editor) {
+      editor.codemirror.setValue('');
+    }
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
     if (title.trim() !== '' && description.trim() !== '') {
       addNote({
-        title,
+        title: title.trim(),
         description,
-        createdAt: Date.now(),
         tags,
+        folderId: folderId || null,
       });
-      setTitle('');
-      setDescription('');
-      setTags([]);
-      if (editor) {
-        editor.codemirror.setValue(''); // Сброс редактора после отправки
-      }
+      resetForm();
     }
   };
 
   return (
-    <div className="box">
+    <form className="box" onSubmit={handleSubmit}>
       <div className="field">
         <label className="label">Заголовок</label>
         <div className="control">
@@ -54,6 +65,25 @@ const NoteForm = ({ addNote }) => {
       </div>
 
       <div className="field">
+        <label className="label">Папка</label>
+        <div className="control">
+          <div className="select is-fullwidth">
+            <select
+              value={folderId}
+              onChange={(event) => setFolderId(event.target.value)}
+            >
+              <option value="">Без папки</option>
+              {folders.map((folder) => (
+                <option key={folder.id} value={folder.id}>
+                  {folder.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div className="field">
         <label className="label">Метки</label>
         <div className="control">
           <TagsInput
@@ -66,12 +96,12 @@ const NoteForm = ({ addNote }) => {
 
       <div className="field">
         <div className="control">
-          <button className="button is-primary" onClick={handleSubmit}>
+          <button className="button is-primary" type="submit">
             Добавить
           </button>
         </div>
       </div>
-    </div>
+    </form>
   );
 };
 

--- a/src/components/NoteList.js
+++ b/src/components/NoteList.js
@@ -1,42 +1,101 @@
-import React from 'react';
-import EditNoteModal from './EditNoteModal';
+import React, { useMemo } from 'react';
 
-const NoteList = ({ notes, onDelete, onEdit }) => {
+const NoteList = ({
+  notes,
+  folders = [],
+  onDelete,
+  onEdit,
+  onMoveNoteToFolder,
+  selectedFolderId,
+}) => {
+  const filteredNotes = useMemo(() => {
+    if (!selectedFolderId) {
+      return notes;
+    }
+    return notes.filter((note) => note.folderId === selectedFolderId);
+  }, [notes, selectedFolderId]);
+
+  const folderNames = useMemo(() => {
+    const lookup = new Map();
+    folders.forEach((folder) => lookup.set(folder.id, folder.name));
+    return lookup;
+  }, [folders]);
+
+  if (filteredNotes.length === 0) {
+    return <p className="has-text-grey">Заметок пока нет.</p>;
+  }
+
   return (
     <div>
-      {notes.map((note) => (
-        <div key={note.createdAt} className="card mb-3">
-          <div className="card-content">
-            <p className="title">{note.title}</p>
-            <p className="subtitle">
-              {new Date(note.createdAt).toLocaleString()}
-              {note.updated && ' (изменено)'}
-            </p>
-            <div className="content">{note.description}</div>
-            <div className="tags">
-              {note.tags && note.tags.length > 0 && (
-                <span className="tag is-primary is-light">
-                  <i className="fas fa-tags"></i> Метки: {note.tags.join(', ')}
-                </span>
-              )}
+      {filteredNotes.map((note) => {
+        const noteFolderName = note.folderId
+          ? folderNames.get(note.folderId)
+          : null;
+
+        return (
+          <div key={note.id} className="card mb-3">
+            <div className="card-content">
+              <p className="title">{note.title}</p>
+              <p className="subtitle">
+                {new Date(note.createdAt).toLocaleString()}
+                {note.updatedAt && (
+                  <span className="ml-2 has-text-grey">
+                    (изменено {new Date(note.updatedAt).toLocaleString()})
+                  </span>
+                )}
+              </p>
+              <div className="content">{note.description}</div>
+              <div className="tags">
+                {note.tags && note.tags.length > 0 && (
+                  <span className="tag is-primary is-light">
+                    <i className="fas fa-tags"></i> Метки: {note.tags.join(', ')}
+                  </span>
+                )}
+              </div>
+              <div className="field mt-3">
+                <label className="label is-size-6">Папка</label>
+                <div className="control">
+                  <div className="select is-small">
+                    <select
+                      value={note.folderId || ''}
+                      onChange={(event) =>
+                        onMoveNoteToFolder(
+                          note.id,
+                          event.target.value || null
+                        )
+                      }
+                    >
+                      <option value="">Без папки</option>
+                      {folders.map((folder) => (
+                        <option key={folder.id} value={folder.id}>
+                          {folder.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  {noteFolderName && (
+                    <p className="help">Текущая папка: {noteFolderName}</p>
+                  )}
+                </div>
+              </div>
             </div>
+            <footer className="card-footer">
+              <button
+                className="button is-warning card-footer-item"
+                onClick={() => onEdit(note)}
+              >
+                <i className="fas fa-edit"></i> Редактировать
+              </button>
+              <button
+                className="button is-danger card-footer-item"
+                onClick={() => onDelete(note.id)}
+              >
+                <i className="fas fa-trash"></i> Удалить
+              </button>
+            </footer>
           </div>
-          <footer className="card-footer">
-            <button
-              className="button is-warning card-footer-item"
-              onClick={() => onEdit(note)}
-            >
-              <i className="fas fa-edit"></i> Редактировать
-            </button>
-            <button
-              className="button is-danger card-footer-item"
-              onClick={() => onDelete(note)}
-            >
-              <i className="fas fa-trash"></i> Удалить
-            </button>
-          </footer>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- persist folders in local storage with validation and consistent identifiers for notes and folders
- add folder selection to note creation and editing along with filtering/moving notes between folders
- refresh the UI components and tests to reflect the new folder management experience

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e3ba937c048325b009046f6719a2a6